### PR TITLE
19.2. Task: getTaskById

### DIFF
--- a/src/main/java/com/crud/tasks/service/DbService.java
+++ b/src/main/java/com/crud/tasks/service/DbService.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor
@@ -15,6 +16,10 @@ public class DbService {
 
     public List<Task> getAllTasks() {
         return repository.findAll();
+    }
+
+    public Optional<Task> getTaskById(Long id) {
+        return repository.findById(id);
     }
 
 }


### PR DESCRIPTION
Please review the task from submodule 19.2.

Alternatively, I can propose a solution that returns a Task object instead of an Optional<Task>, but additionally throws an exception if the **Id** given as an argument doesn't exist.
It seems to me that both solutions are ok, depending on how the program will look in the future.